### PR TITLE
Update web-dialog.ts

### DIFF
--- a/src/lib/web-dialog.ts
+++ b/src/lib/web-dialog.ts
@@ -88,7 +88,6 @@ export class WebDialog<R = any> extends HTMLElement {
 		this.onKeyDown = this.onKeyDown.bind(this);
 
 		// Set aria attributes
-		this.setAttribute("aria-modal", "true");
 		this.$dialog.setAttribute("role", "alertdialog");
 	}
 
@@ -96,6 +95,7 @@ export class WebDialog<R = any> extends HTMLElement {
 	 * Attaches event listeners when connected.
 	 */
 	connectedCallback () {
+		this.setAttribute("aria-modal", "true");
 		this.$backdrop.addEventListener("click", this.onBackdropClick);
 	}
 


### PR DESCRIPTION
Hi,

First of all thanks for creating this module. I ran into an issue recently with Chrome. Instantiating a web-dialog element programmatically caused the following error:
`Uncaught DOMException: Failed to construct 'CustomElement': The result must not have attributes
    at <anonymous>:1:10`

To mitigate this I've moved setting the aria-modal attribute from the constructor to the connectedCallback method.

Hope this constitutes an improvement.

Regards,
Hans